### PR TITLE
Fix callback url - FIX #7

### DIFF
--- a/lib/omniauth/strategies/amazon.rb
+++ b/lib/omniauth/strategies/amazon.rb
@@ -22,7 +22,7 @@ module OmniAuth
 
       def build_access_token
         token_params = {
-          :redirect_uri => callback_url,
+          :redirect_uri => callback_url.split('?').first,
           :client_id => client.id,
           :client_secret => client.secret
         }


### PR DESCRIPTION
@wingrunr21 Amazon returns *invalid_grant: redirect_uri* if query string is present in callback url or you can say if it doesn't match with callback url specified in amazon developer app.

**Note:** We don't specify query string with callback url in amazon developer app. For your convenience i am attaching a screenshot here.
<img width="1440" alt="screen shot 2016-02-26 at 9 16 29 pm" src="https://cloud.githubusercontent.com/assets/1305918/13356991/3f8b5cbe-dcce-11e5-9f22-4569325dcb5b.png">
 