### PR TITLE
Add ability to pass custom state param

### DIFF
--- a/lib/omniauth/amazon/version.rb
+++ b/lib/omniauth/amazon/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Amazon
-    VERSION = "1.0.1"
+    VERSION = "1.1.0"
   end
 end

--- a/omniauth-amazon.gemspec
+++ b/omniauth-amazon.gemspec
@@ -6,8 +6,8 @@ require 'omniauth/amazon/version'
 Gem::Specification.new do |spec|
   spec.name          = "omniauth-amazon"
   spec.version       = OmniAuth::Amazon::VERSION
-  spec.authors       = ["Stafford Brunk"]
-  spec.email         = ["stafford.brunk@gmail.com"]
+  spec.authors       = ["Stafford Brunk", "Lenart Rudel"]
+  spec.email         = ["stafford.brunk@gmail.com", "lenart.rudel@gmail.com"]
   spec.description   = %q{Login with Amazon OAuth2 strategy for OmniAuth 1.0}
   spec.summary       = %q{Login with Amazon OAuth2 strategy for OmniAuth 1.0}
   spec.homepage      = "https://github.com/wingrunr21/omniauth-amazon"
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'omniauth', '~> 1.0'
   spec.add_dependency 'omniauth-oauth2', '~> 1.1'
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency 'rspec', '~> 2.13'
+  spec.add_development_dependency 'rspec', '>= 2.13'
   spec.add_development_dependency 'rack-test'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'webmock'

--- a/spec/omniauth/strategies/amazon_spec.rb
+++ b/spec/omniauth/strategies/amazon_spec.rb
@@ -26,4 +26,10 @@ describe OmniAuth::Strategies::Amazon do
       expect(subject.callback_path).to eq('/auth/amazon/callback')
     end
   end
+
+  describe '#scope' do
+    it 'passes custom state to Amazon site'
+    it 'generates random state value when one is not explicitly provided'
+    it 'strips state from callback_url query params'
+  end
 end


### PR DESCRIPTION
According to specs passing an arbitrary `&state=` param should be allowed. This PR checks for custom `state` and uses `SecureRandom.hex(24)` as a fallback.