### PR TITLE
Do not include query parameters in callback URLs

### DIFF
--- a/lib/omniauth/strategies/amazon.rb
+++ b/lib/omniauth/strategies/amazon.rb
@@ -57,6 +57,10 @@ module OmniAuth
         params = {:params => { :access_token => access_token.token}}
         @raw_info ||= access_token.client.request(:get, url, params).parsed
       end
+
+      def callback_url
+        full_host + script_name + callback_path
+      end
     end
   end
 end

--- a/spec/omniauth/strategies/amazon_spec.rb
+++ b/spec/omniauth/strategies/amazon_spec.rb
@@ -26,4 +26,14 @@ describe OmniAuth::Strategies::Amazon do
       expect(subject.callback_path).to eq('/auth/amazon/callback')
     end
   end
+
+  describe '#callback_url' do
+    it 'does not include query parameters' do
+      allow(subject).to receive(:full_host).and_return('https://example.com')
+      allow(subject).to receive(:script_name).and_return('/sub_uri')
+      allow(subject).to receive(:query_string).and_return('?foo=bar')
+      
+       expect(subject.callback_url).to eq('https://example.com/sub_uri/auth/amazon/callback')
+    end
+  end
 end


### PR DESCRIPTION
The callback url must always match the one defined at developer.amazon.com. Passing on query parameters will result in a mismatch, and result in an error.

This is the same approach taken in other OAuth2 omniauth strategies, including https://github.com/omniauth/omniauth-github/commit/d8d5c217f560b7021760882c3c7bdc3e971e0fd8 and https://github.com/zquestz/omniauth-google-oauth2/commit/1adf026369850e5b8895f95d0294965975958720