### PR TITLE
Use newer LwA APIs to retrieve user info

### DIFF
--- a/lib/omniauth/amazon/version.rb
+++ b/lib/omniauth/amazon/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Amazon
-    VERSION = "1.0.1"
+    VERSION = "1.1.0"
   end
 end

--- a/lib/omniauth/strategies/amazon.rb
+++ b/lib/omniauth/strategies/amazon.rb
@@ -7,7 +7,7 @@ module OmniAuth
       option :name, 'amazon'
 
       option :client_options, {
-        :site => 'https://www.amazon.com/',
+        :site => 'https://api.amazon.com/',
         :authorize_url => 'https://www.amazon.com/ap/oa',
         :token_url => 'https://api.amazon.com/auth/o2/token'
       }
@@ -30,18 +30,18 @@ module OmniAuth
         client.auth_code.get_token(verifier, token_params)
       end
 
-      uid { raw_info['Profile']['CustomerId'] }
+      uid { raw_info['user_id'] }
 
       info do
         {
-          'email' => raw_info['Profile']['PrimaryEmail'],
-          'name' => raw_info['Profile']['Name']
+          'email' => raw_info['email'],
+          'name' => raw_info['name']
         }
       end
 
       extra do
         {
-          'postal_code' => raw_info['Profile']['PostalCode']
+          'postal_code' => raw_info['postal_code']
         }
       end
 
@@ -53,7 +53,7 @@ module OmniAuth
         #
         #@raw_info ||= access_token.get('/ap/user/profile').parsed
 
-        url = "/ap/user/profile"
+        url = "/user/profile"
         params = {:params => { :access_token => access_token.token}}
         @raw_info ||= access_token.client.request(:get, url, params).parsed
       end

--- a/spec/omniauth/strategies/amazon_spec.rb
+++ b/spec/omniauth/strategies/amazon_spec.rb
@@ -9,7 +9,7 @@ describe OmniAuth::Strategies::Amazon do
 
   describe '#client' do
     it 'should have the correct Amazon site' do
-      expect(subject.client.site).to eq("https://www.amazon.com/")
+      expect(subject.client.site).to eq("https://api.amazon.com/")
     end
 
     it 'should have the correct authorization url' do
@@ -34,6 +34,60 @@ describe OmniAuth::Strategies::Amazon do
       allow(subject).to receive(:query_string).and_return('?foo=bar')
       
        expect(subject.callback_url).to eq('https://example.com/sub_uri/auth/amazon/callback')
+    end
+  end
+
+  describe '#raw_info' do
+    let(:user_id) { 'amzn1.account.AHECIGNDVJG5QR6DRQFX5ZQVAOAA' }
+    let(:user_name) { 'Philip Walsh' }
+    let(:email) { 'pipwalshlx@gmail.com' }
+    let(:response_body) { { "user_id" => user_id, "name" => user_name, "email" => email } }
+    let(:response) { double(parsed: response_body) }
+
+    let(:access_token) { 'some-token' }
+    let(:client) { double(request: response) }
+
+    before do
+      allow_any_instance_of(OmniAuth::Strategies::Amazon).to receive(:access_token).and_return(
+        double(options: {}, token: access_token, client: client)
+      )
+    end
+
+    it 'calls the right Login with Amazon endpoint' do
+      expect(client).to receive(:request).with(:get, "/user/profile", {
+        params: { access_token: access_token }
+      })
+      expect(subject.raw_info).to eq(response_body)
+    end
+
+    context '#uid' do
+      before do
+        allow_any_instance_of(OmniAuth::Strategies::Amazon).to receive(:raw_info).and_return(response_body)
+      end
+
+      it 'extracts the Amazon user ID correctly' do
+        expect(subject.uid).to eq(user_id)
+      end
+    end
+
+    context '#info' do
+      before do
+        allow_any_instance_of(OmniAuth::Strategies::Amazon).to receive(:raw_info).and_return(response_body)
+      end
+
+      it 'extracts the Amazon user ID correctly' do
+        expect(subject.info).to eq({'email' => email, 'name' => user_name})
+      end
+    end
+
+    context '#extra' do
+      before do
+        allow_any_instance_of(OmniAuth::Strategies::Amazon).to receive(:raw_info).and_return(response_body)
+      end
+
+      it 'extracts the Amazon user ID correctly' do
+        expect(subject.extra).to eq({'postal_code' => nil})
+      end
     end
   end
 end


### PR DESCRIPTION
Login with Amazon APIs living under the `www.amazon.com` domain are not meant to be used in non-browser environments as doing so may lead to HTML for captcha challenges being returned in place of the expected JSON. This would result in the oauth integration failing repeatedly.

Those APIs are also unsupported by Amazon with only the ones living under the `api.amazon.com` host being properly documented (examples [here](https://developer.amazon.com/docs/app-submission-api/auth.html#request-lwa-access-token) and [there](https://developer.amazon.com/docs/login-with-amazon/obtain-customer-profile.html#call-profile-endpoint)).